### PR TITLE
Texturing segfault fix

### DIFF
--- a/src/aliceVision/mesh/Texturing.cpp
+++ b/src/aliceVision/mesh/Texturing.cpp
@@ -866,8 +866,9 @@ void Texturing::replaceMesh(const std::string& otherMeshPath, bool flipNormals)
     // keep previous mesh/visibilities as reference
     Mesh* refMesh = mesh;
     // set pointers to null to avoid deallocation by 'loadFromObj'
-    mesh = nullptr;
     mesh->pointsVisibilities.resize(0);
+    mesh = nullptr;
+    
     // load input obj file
     loadOBJWithAtlas(otherMeshPath, flipNormals);
     // allocate pointsVisibilities for new internal mesh


### PR DESCRIPTION
<!-- Checklist before submission:

 - I have read the [contribution guidelines](../CONTRIBUTING.md).
 - I have updated the documentation, if applicable.
 - I have ensured that the change is tested somewhere.
 - I have followed the prevailing code style (for history readability and limit conflicts for maintainance).

-->
## Description

Fixed reference after null crash on texturing replaceMesh method called when not using a basic unwrap

## Features list

- [ X] Fixes https://github.com/alicevision/meshroom/issues/1107

## Implementation remarks
Introduced in diff between 2.3.0 & 2.2.0 

<!--
Explain main implementation choices.
It is also the right place to ask for feedback and help when you hesitate on the implementation.
-->

